### PR TITLE
Specify lgpio backend in code

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ ECHO → BCM24 (pin 18) 请使用 3.3V 电平转换
 pip install gpiozero lgpio
 ```
 
+代码中已显式指定 `lgpio` 作为 GPIO 后端，因此无需额外设置环境变量。
+
 ## 示例
 
 仓库包含 `ultrasonic_device.py` 类和 `main.py` 示例，可用于在树莓派5上读取 HC-SR04 超声波传感器的距离数据。通过命令行参数可设置检测周期和针脚。

--- a/ultrasonic_device.py
+++ b/ultrasonic_device.py
@@ -1,4 +1,9 @@
-from gpiozero import DistanceSensor
+from gpiozero import DistanceSensor, Device
+from gpiozero.pins.lgpio import LGPIOFactory
+
+# Explicitly select ``lgpio`` as the GPIO backend so the code works on
+# Raspberry Pi 5 without relying on environment variables or ``pigpio``.
+Device.pin_factory = LGPIOFactory()
 
 
 class UltrasonicDevice:


### PR DESCRIPTION
## Summary
- ensure gpiozero uses lgpio by default
- document that the backend is specified in the code

## Testing
- `python3 -m py_compile main.py ultrasonic_device.py`


------
https://chatgpt.com/codex/tasks/task_e_6871265f82588331b1107386c0d52b74