### PR TITLE
Set default pins to BCM18/17

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Pi5的超声波传感器使用示例，代码基于 `gpiozero` 库实现。
 ```
 VCC  → Pi 5V (pin 2)
 GND  → Pi GND
-TRIG → BCM23 (pin 16)
-ECHO → BCM24 (pin 18) 请使用 3.3V 电平转换
+TRIG → BCM18 (pin 12)
+ECHO → BCM17 (pin 11) 请使用 3.3V 电平转换
 ```
 
 ## 依赖
@@ -27,7 +27,7 @@ pip install gpiozero lgpio
 ### 运行方式
 
 ```bash
-python3 main.py --interval 1 --trig 23 --echo 24 --max-dist 2.0
+python3 main.py --interval 1 --trig 18 --echo 17 --max-dist 2.0
 ```
 
 终端会按指定间隔打印测定的距离。
@@ -35,6 +35,6 @@ python3 main.py --interval 1 --trig 23 --echo 24 --max-dist 2.0
 ### 参数说明
 
 - `-i/--interval` 测量间隔（秒），默认1.0
-- `--trig` TRIG 针脚（BCM），默认23
-- `--echo` ECHO 针脚（BCM），默认24
+- `--trig` TRIG 针脚（BCM），默认18
+- `--echo` ECHO 针脚（BCM），默认17
 - `--max-dist` 最大测量距离（米），默认2.0

--- a/main.py
+++ b/main.py
@@ -12,8 +12,8 @@ def main():
         default=1.0,
         help="测量间隔 (秒)",
     )
-    parser.add_argument("--trig", type=int, default=23, help="TRIG 针脚 (BCM)")
-    parser.add_argument("--echo", type=int, default=24, help="ECHO 针脚 (BCM)")
+    parser.add_argument("--trig", type=int, default=18, help="TRIG 针脚 (BCM)")
+    parser.add_argument("--echo", type=int, default=17, help="ECHO 针脚 (BCM)")
     parser.add_argument(
         "--max-dist",
         type=float,

--- a/ultrasonic_device.py
+++ b/ultrasonic_device.py
@@ -7,7 +7,7 @@ Device.pin_factory = LGPIOFactory()
 
 
 class UltrasonicDevice:
-    def __init__(self, trig_pin=23, echo_pin=24, max_distance=2.0):
+    def __init__(self, trig_pin=18, echo_pin=17, max_distance=2.0):
         """Initialize the ultrasonic sensor using gpiozero.
 
         Parameters


### PR DESCRIPTION
## Summary
- set default `trig` and `echo` pins to BCM18 and BCM17
- update README accordingly

## Testing
- `python3 -m py_compile main.py ultrasonic_device.py`


------
https://chatgpt.com/codex/tasks/task_e_68712d7b49888331b15d7eec19d5a0f0